### PR TITLE
fix: lowercase CCTV in m3u logo filename

### DIFF
--- a/src/sources/utils.ts
+++ b/src/sources/utils.ts
@@ -86,8 +86,9 @@ export const default_txt_filter: ISource['filter'] = (raw, caller, collectFn): [
       if (!url) {
         continue;
       }
+      const logoName = name.replace(/CCTV/g, 'cctv');
       const extinf = `#EXTINF:-1 tvg-id="${name}" tvg-name="${name}" \
-tvg-logo="https://tv-res.pages.dev/logo/${name}.png" group-title="${group}",${name}`;
+tvg-logo="https://tv-res.pages.dev/logo/${logoName}.png" group-title="${group}",${name}`;
       collectM3uSource(extinf, url, collectFn);
       m3uLines.push(extinf, url);
       count++;

--- a/test/sources/utils.test.ts
+++ b/test/sources/utils.test.ts
@@ -64,4 +64,10 @@ describe('default_txt_filter', () => {
     });
     expect(count).toBe(2);
   });
+
+  it('should use lowercase cctv in logo filename', () => {
+    const raw = ['#央视#', 'CCTV1,https://cctv1.com'].join('\n');
+    const [m3u] = default_txt_filter(raw, 'normal', () => {});
+    expect(m3u).toContain('tvg-logo="https://tv-res.pages.dev/logo/cctv1.png"');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update m3u logo URL generation in `default_txt_filter`
- replace `CCTV` with `cctv` in the logo file name segment only
- add unit test to lock expected behavior

## Testing
- `pnpm test test/sources/utils.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a567bf81-e125-423a-8dea-e698784b67d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a567bf81-e125-423a-8dea-e698784b67d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

