### PR TITLE
refactor: replace XML parsing with xml2js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/markdown-it": "14.1.2",
     "@types/node": "22.2.0",
     "@types/opencc-js": "1.0.3",
+    "@types/xml2js": "^0.4.14",
     "@vitest/coverage-v8": "^2.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.15.0",
@@ -51,12 +52,12 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "fast-xml-parser": "^5.5.5",
     "koa": "2.15.3",
     "koa-router": "12.0.1",
     "koa-static": "5.0.0",
     "markdown-it": "14.1.0",
-    "opencc-js": "1.0.5"
+    "opencc-js": "1.0.5",
+    "xml2js": "^0.6.2"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
-      fast-xml-parser:
-        specifier: ^5.5.5
-        version: 5.5.5
       koa:
         specifier: 2.15.3
         version: 2.15.3
@@ -32,6 +29,9 @@ importers:
       opencc-js:
         specifier: 1.0.5
         version: 1.0.5
+      xml2js:
+        specifier: ^0.6.2
+        version: 0.6.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -57,6 +57,9 @@ importers:
       '@types/opencc-js':
         specifier: 1.0.3
         version: 1.0.3
+      '@types/xml2js':
+        specifier: ^0.4.14
+        version: 0.4.14
       '@vitest/coverage-v8':
         specifier: ^2.1.0
         version: 2.1.9(vitest@2.1.9(@types/node@22.2.0))
@@ -664,8 +667,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  '@rollup/wasm-node@4.59.0':
-    resolution: {integrity: sha512-cKB/Pe05aJWQYw3UFS79Id+KVXdExBxWful0+CSl24z3ukwOgBSy6l39XZNwfm3vCh/fpUrAAs+T7PsJ6dC8NA==}
+  '@rollup/wasm-node@4.60.1':
+    resolution: {integrity: sha512-FAfGj5Ferzyna11iUwGdkYus/Y9d/H75PEpsseP5DZOsEsyPvP/Q7mJiSXhUYSEmyfHPaZyC8EsJCjqzDbtcfg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -749,6 +752,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/xml2js@0.4.14':
+    resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -1252,13 +1258,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
-
-  fast-xml-parser@5.5.5:
-    resolution: {integrity: sha512-NLY+V5NNbdmiEszx9n14mZBseJTC50bRq1VHsaxOmR72JDuZt+5J1Co+dC/4JPnyq+WrIHNM69r0sqf7BMb3Mg==}
-    hasBin: true
-
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1701,10 +1700,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
-
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -1828,6 +1823,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1911,9 +1910,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strnum@2.2.0:
-    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -2151,6 +2147,14 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xml2js@0.6.2:
+    resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
 
   ylru@1.4.0:
     resolution: {integrity: sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==}
@@ -2506,7 +2510,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rollup/wasm-node@4.59.0':
+  '@rollup/wasm-node@4.60.1':
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -2613,6 +2617,10 @@ snapshots:
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
+      '@types/node': 22.2.0
+
+  '@types/xml2js@0.4.14':
+    dependencies:
       '@types/node': 22.2.0
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4)(typescript@5.5.4))(eslint@9.39.4)(typescript@5.5.4)':
@@ -3221,16 +3229,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-builder@1.1.3:
-    dependencies:
-      path-expression-matcher: 1.1.3
-
-  fast-xml-parser@5.5.5:
-    dependencies:
-      fast-xml-builder: 1.1.3
-      path-expression-matcher: 1.1.3
-      strnum: 2.2.0
-
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3695,8 +3693,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.1.3: {}
-
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -3780,6 +3776,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  sax@1.6.0: {}
+
   semver@7.7.4: {}
 
   setprototypeof@1.1.0: {}
@@ -3841,8 +3839,6 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
-
-  strnum@2.2.0: {}
 
   sucrase@3.35.1:
     dependencies:
@@ -3935,7 +3931,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.8)(tsx@4.21.0)
       resolve-from: 5.0.0
-      rollup: '@rollup/wasm-node@4.59.0'
+      rollup: '@rollup/wasm-node@4.60.1'
       source-map: 0.8.0-beta.0
       sucrase: 3.35.1
       tree-kill: 1.2.2
@@ -4011,7 +4007,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.8
-      rollup: '@rollup/wasm-node@4.59.0'
+      rollup: '@rollup/wasm-node@4.60.1'
     optionalDependencies:
       '@types/node': 22.2.0
       fsevents: 2.3.3
@@ -4081,6 +4077,13 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xml2js@0.6.2:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
 
   ylru@1.4.0: {}
 

--- a/src/epgs/epg_pw.ts
+++ b/src/epgs/epg_pw.ts
@@ -16,39 +16,18 @@ import { mkdir } from 'fs/promises';
 import {
   buildXmlDocument,
   normalizeXmlList,
-  parseXmlDocument,
   readXmlAttr,
-  readXmlText,
-  type XmlNodeWithAttributes,
+  readXmltvChannelName,
+  readXmltvProgrammeTitle,
+  parseXmltvRoot,
+  type XmltvChannelNode,
+  type XmltvNode,
+  type XmltvProgrammeNode,
 } from './xml';
-
-type EpgPwTvNode = {
-  channel?: EpgPwChannelNode | EpgPwChannelNode[];
-  programme?: EpgPwProgrammeNode | EpgPwProgrammeNode[];
-};
 
 interface EpgPwChannel {
   id: string;
   name: string;
-}
-
-type EpgPwTextNode = string | XmlNodeWithAttributes | Array<string | XmlNodeWithAttributes>;
-
-interface EpgPwChannelNode extends XmlNodeWithAttributes {
-  $?: {
-    id?: string;
-  };
-  'display-name'?: EpgPwTextNode | EpgPwTextNode[];
-}
-
-interface EpgPwProgrammeNode extends XmlNodeWithAttributes {
-  $?: {
-    start?: string;
-    stop?: string;
-    channel?: string;
-  };
-  title?: EpgPwTextNode | EpgPwTextNode[];
-  desc?: EpgPwTextNode | EpgPwTextNode[];
 }
 
 export interface PWEpgJson {
@@ -145,8 +124,7 @@ function parsePwEpgXml(xml: string): {
   channels: EpgPwChannelNode[];
   programmes: EpgPwProgrammeNode[];
 } {
-  const parsed = parseXmlDocument<{ tv?: EpgPwTvNode }>(xml);
-  const tv = parsed?.tv;
+  const tv = parseXmltvRoot(xml) as XmltvNode | null;
   if (!tv) {
     return { channels: [], programmes: [] };
   }
@@ -213,7 +191,7 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
           }
         }
         const currentChannel = chList[0];
-        const currentChannelName = readXmlText(currentChannel?.['display-name']).toLowerCase();
+        const currentChannelName = readXmltvChannelName(currentChannel).toLowerCase();
         const json: EpgChannelJson = {
           channel: currentChannelName,
           epg_data: progList
@@ -225,7 +203,7 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
               return {
                 start: formatTime(utcDate(start)),
                 end: formatTime(utcDate(stop)),
-                title: readXmlText(prog.title),
+                title: readXmltvProgrammeTitle(prog),
               };
             })
             .filter((item): item is EpgChannelJson['epg_data'][number] => item !== null),

--- a/src/epgs/epg_pw.ts
+++ b/src/epgs/epg_pw.ts
@@ -24,8 +24,9 @@ import {
   type XmltvNode,
   type XmltvProgrammeNode,
 } from './xml';
+import { formatHourMinute, parseXmltvUtcTimestamp } from './time';
 
-interface EpgPwChannel {
+export interface EpgPwChannel {
   id: string;
   name: string;
 }
@@ -56,7 +57,7 @@ export interface PWEpgProgrammeItem {
  * 从 epg.pw 频道列表页 HTML 中提取频道 ID 与名称
  * 链接格式: href="/last/464609.html?lang=zh-hans"
  */
-function parseChannelListFromHtml(html: string): EpgPwChannel[] {
+export function parseChannelListFromHtml(html: string): EpgPwChannel[] {
   const regex = /href="\/last\/(\d+)\.html\?lang=zh-hans"[^>]*>([^<]+)<\/a>/g;
   const channels: EpgPwChannel[] = [];
   const seen = new Set<string>();
@@ -81,27 +82,6 @@ function formatDate(date: Date): string {
   return `${y}${m}${d}`;
 }
 
-function utcDate(timeStr: string): Date {
-  // 1. 提取各个部分 (通过字符串截取)
-  const year = +timeStr.substring(0, 4);
-  const month = +timeStr.substring(4, 6) - 1; // 月份从 0 开始计数 (0 = 一月)
-  const day = +timeStr.substring(6, 8);
-  const hour = +timeStr.substring(8, 10);
-  const minute = +timeStr.substring(10, 12);
-  const second = +timeStr.substring(12, 14);
-
-  // 2. 使用 Date.UTC 创建 UTC 时间对象
-  // 注：末尾的 +0000 表示这是 UTC 时间
-  const date = new Date(Date.UTC(year, month, day, hour, minute, second));
-  return date;
-}
-
-function formatTime(date: Date): string {
-  const h = String(date.getHours()).padStart(2, '0');
-  const m = String(date.getMinutes()).padStart(2, '0');
-  return `${h}:${m}`;
-}
-
 async function fetchChannelEpg(channelId: string, date: string): Promise<string | null> {
   const url = `https://epg.pw/api/epg.xml?lang=zh-hans&date=${date}&channel_id=${channelId}`;
   try {
@@ -120,7 +100,7 @@ function channelIdFromNode(node: EpgPwChannelNode): string | null {
 /**
  * 解析单份 epg.pw API 返回的 XMLTV 片段
  */
-function parsePwEpgXml(xml: string): {
+export function parsePwEpgXml(xml: string): {
   channels: EpgPwChannelNode[];
   programmes: EpgPwProgrammeNode[];
 } {
@@ -131,6 +111,30 @@ function parsePwEpgXml(xml: string): {
   return {
     channels: normalizeXmlList(tv.channel),
     programmes: normalizeXmlList(tv.programme),
+  };
+}
+
+export function buildPwChannelJson(
+  channelNode: EpgPwChannelNode | undefined,
+  programmes: EpgPwProgrammeNode[]
+): EpgChannelJson {
+  const channel = readXmltvChannelName(channelNode).toLowerCase();
+
+  return {
+    channel,
+    epg_data: programmes
+      .map((programme) => {
+        const startTime = parseXmltvUtcTimestamp(readXmlAttr(programme, 'start'));
+        const endTime = parseXmltvUtcTimestamp(readXmlAttr(programme, 'stop'));
+        if (!startTime || !endTime) return null;
+
+        return {
+          start: formatHourMinute(startTime),
+          end: formatHourMinute(endTime),
+          title: readXmltvProgrammeTitle(programme),
+        };
+      })
+      .filter((item): item is EpgChannelJson['epg_data'][number] => item !== null),
   };
 }
 
@@ -191,23 +195,8 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
           }
         }
         const currentChannel = chList[0];
-        const currentChannelName = readXmltvChannelName(currentChannel).toLowerCase();
-        const json: EpgChannelJson = {
-          channel: currentChannelName,
-          epg_data: progList
-            .map((prog) => {
-              const start = readXmlAttr(prog, 'start');
-              const stop = readXmlAttr(prog, 'stop');
-              if (!start || !stop) return null;
-
-              return {
-                start: formatTime(utcDate(start)),
-                end: formatTime(utcDate(stop)),
-                title: readXmltvProgrammeTitle(prog),
-              };
-            })
-            .filter((item): item is EpgChannelJson['epg_data'][number] => item !== null),
-        };
+        const json = buildPwChannelJson(currentChannel, progList);
+        const currentChannelName = json.channel;
         const savePath = await mkdir(path.join(basePath, currentChannelName), { recursive: true });
         await writeFile(
           path.join(savePath as string, `${date}.json`),

--- a/src/epgs/epg_pw.ts
+++ b/src/epgs/epg_pw.ts
@@ -30,29 +30,6 @@ export interface EpgPwChannel {
   id: string;
   name: string;
 }
-
-export interface PWEpgJson {
-  end_date: string;
-  name: string;
-  info_url: string;
-  country: string;
-  description: string | null;
-  error_message: string;
-  provider: string;
-  source_url: string;
-  offset: string;
-  timezone: string;
-  error_code: number;
-  start_date: string;
-  icon: string;
-  epg_list: PWEpgProgrammeItem[];
-}
-
-export interface PWEpgProgrammeItem {
-  desc: string;
-  start_date: string;
-  title: string;
-}
 /**
  * 从 epg.pw 频道列表页 HTML 中提取频道 ID 与名称
  * 链接格式: href="/last/464609.html?lang=zh-hans"
@@ -93,7 +70,7 @@ async function fetchChannelEpg(channelId: string, date: string): Promise<string 
   }
 }
 
-function channelIdFromNode(node: EpgPwChannelNode): string | null {
+function channelIdFromNode(node: XmltvChannelNode): string | null {
   return readXmlAttr(node, 'id') || null;
 }
 
@@ -101,8 +78,8 @@ function channelIdFromNode(node: EpgPwChannelNode): string | null {
  * 解析单份 epg.pw API 返回的 XMLTV 片段
  */
 export function parsePwEpgXml(xml: string): {
-  channels: EpgPwChannelNode[];
-  programmes: EpgPwProgrammeNode[];
+  channels: XmltvChannelNode[];
+  programmes: XmltvProgrammeNode[];
 } {
   const tv = parseXmltvRoot(xml) as XmltvNode | null;
   if (!tv) {
@@ -115,8 +92,8 @@ export function parsePwEpgXml(xml: string): {
 }
 
 export function buildPwChannelJson(
-  channelNode: EpgPwChannelNode | undefined,
-  programmes: EpgPwProgrammeNode[]
+  channelNode: XmltvChannelNode | undefined,
+  programmes: XmltvProgrammeNode[]
 ): EpgChannelJson {
   const channel = readXmltvChannelName(channelNode).toLowerCase();
 
@@ -170,8 +147,8 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
   }
 
   const seenChannelIds = new Set<string>();
-  const channelNodes: EpgPwChannelNode[] = [];
-  const programmeNodes: EpgPwProgrammeNode[] = [];
+  const channelNodes: XmltvChannelNode[] = [];
+  const programmeNodes: XmltvProgrammeNode[] = [];
   // const epgDir = makeEpgDir();
   const basePath = path.join(__dirname, '../../m3u/epg/pw-7');
 

--- a/src/epgs/epg_pw.ts
+++ b/src/epgs/epg_pw.ts
@@ -76,17 +76,21 @@ function channelIdFromNode(node: XmltvChannelNode): string | null {
 
 /**
  * 解析单份 epg.pw API 返回的 XMLTV 片段
+ * 该接口按 channel_id 请求，响应中只会包含当前频道的 <channel> 与其 <programme> 列表
  */
 export function parsePwEpgXml(xml: string): {
-  channels: XmltvChannelNode[];
+  channel: XmltvChannelNode | null;
   programmes: XmltvProgrammeNode[];
 } {
   const tv = parseXmltvRoot(xml) as XmltvNode | null;
   if (!tv) {
-    return { channels: [], programmes: [] };
+    return { channel: null, programmes: [] };
   }
+
+  const [channel] = normalizeXmlList(tv.channel);
+
   return {
-    channels: normalizeXmlList(tv.channel),
+    channel: channel ?? null,
     programmes: normalizeXmlList(tv.programme),
   };
 }
@@ -162,24 +166,23 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
       for (const result of results) {
         if (result.status !== 'fulfilled' || !result.value) continue;
 
-        const { channels: chList, programmes: progList } = parsePwEpgXml(result.value);
+        const { channel, programmes } = parsePwEpgXml(result.value);
+        if (!channel) continue;
 
-        for (const ch of chList) {
-          const chId = channelIdFromNode(ch);
-          if (chId && !seenChannelIds.has(chId)) {
-            seenChannelIds.add(chId);
-            channelNodes.push(ch);
-          }
+        const channelId = channelIdFromNode(channel);
+        if (channelId && !seenChannelIds.has(channelId)) {
+          seenChannelIds.add(channelId);
+          channelNodes.push(channel);
         }
-        const currentChannel = chList[0];
-        const json = buildPwChannelJson(currentChannel, progList);
+
+        const json = buildPwChannelJson(channel, programmes);
         const currentChannelName = json.channel;
         const savePath = await mkdir(path.join(basePath, currentChannelName), { recursive: true });
         await writeFile(
           path.join(savePath as string, `${date}.json`),
           JSON.stringify(json, null, 2)
         );
-        programmeNodes.push(...progList);
+        programmeNodes.push(...programmes);
       }
 
       const progress = Math.min(i + batchSize, channels.length);

--- a/src/epgs/epg_pw.ts
+++ b/src/epgs/epg_pw.ts
@@ -4,33 +4,23 @@
  * 流程：
  *  1. 访问 https://epg.pw/areas/cn.html?lang=zh-hans 提取频道 ID 与名称
  *  2. 对每个频道调用 https://epg.pw/api/epg.xml?lang=zh-hans&date=YYYYMMDD&channel_id=ID
- *  3. 使用 fast-xml-parser 解析各响应中的 <channel> 与 <programme> 节点
- *  4. 去重合并后由 XMLBuilder 输出一份完整的 XMLTV XML
+ *  3. 使用 xml2js 解析各响应中的 <channel> 与 <programme> 节点
+ *  4. 去重合并后由 Builder 输出一份完整的 XMLTV XML
  */
-
-import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 
 import { writeEpgJsonFromXml } from '../file';
 import type { EpgChannelJson } from './parser';
 import { writeFile } from 'fs/promises';
 import path from 'path';
 import { mkdir } from 'fs/promises';
-
-/** 与 src/epgs/parser.ts 保持一致，便于结构一致 */
-const PW_EPG_PARSER_OPTIONS = {
-  ignoreAttributes: false,
-  attributeNamePrefix: '@_' as const,
-  /** 单条也解析为数组，避免手写分支 */
-  isArray: (tagName: string) => tagName === 'channel' || tagName === 'programme',
-};
-
-const epgPwParser = new XMLParser(PW_EPG_PARSER_OPTIONS);
-
-const epgPwBuilder = new XMLBuilder({
-  ignoreAttributes: false,
-  attributeNamePrefix: '@_',
-  suppressEmptyNode: true,
-});
+import {
+  buildXmlDocument,
+  normalizeXmlList,
+  parseXmlDocument,
+  readXmlAttr,
+  readXmlText,
+  type XmlNodeWithAttributes,
+} from './xml';
 
 type EpgPwTvNode = {
   channel?: EpgPwChannelNode | EpgPwChannelNode[];
@@ -42,26 +32,21 @@ interface EpgPwChannel {
   name: string;
 }
 
-type EpgPwTextNode =
-  | string
-  | {
-      '#text'?: string;
-      [key: string]: unknown;
-    };
+type EpgPwTextNode = string | XmlNodeWithAttributes | Array<string | XmlNodeWithAttributes>;
 
-interface EpgPwXmlNodeBase {
-  [key: string]: unknown;
-}
-
-interface EpgPwChannelNode extends EpgPwXmlNodeBase {
-  '@_id'?: string;
+interface EpgPwChannelNode extends XmlNodeWithAttributes {
+  $?: {
+    id?: string;
+  };
   'display-name'?: EpgPwTextNode | EpgPwTextNode[];
 }
 
-interface EpgPwProgrammeNode extends EpgPwXmlNodeBase {
-  '@_start'?: string;
-  '@_stop'?: string;
-  '@_channel'?: string;
+interface EpgPwProgrammeNode extends XmlNodeWithAttributes {
+  $?: {
+    start?: string;
+    stop?: string;
+    channel?: string;
+  };
   title?: EpgPwTextNode | EpgPwTextNode[];
   desc?: EpgPwTextNode | EpgPwTextNode[];
 }
@@ -149,16 +134,8 @@ async function fetchChannelEpg(channelId: string, date: string): Promise<string 
   }
 }
 
-function normalizeTagList<T>(node: unknown): T[] {
-  if (node === undefined || node === null) return [];
-  return Array.isArray(node) ? (node as T[]) : [node as T];
-}
-
 function channelIdFromNode(node: EpgPwChannelNode): string | null {
-  const id = node['@_id'];
-  if (id === undefined || id === null) return null;
-  const s = String(id).trim();
-  return s || null;
+  return readXmlAttr(node, 'id') || null;
 }
 
 /**
@@ -168,17 +145,15 @@ function parsePwEpgXml(xml: string): {
   channels: EpgPwChannelNode[];
   programmes: EpgPwProgrammeNode[];
 } {
-  try {
-    const parsed = epgPwParser.parse(xml) as { tv?: EpgPwTvNode };
-    const tv = parsed?.tv;
-    if (!tv) return { channels: [], programmes: [] };
-    return {
-      channels: normalizeTagList<EpgPwChannelNode>(tv.channel),
-      programmes: normalizeTagList<EpgPwProgrammeNode>(tv.programme),
-    };
-  } catch {
+  const parsed = parseXmlDocument<{ tv?: EpgPwTvNode }>(xml);
+  const tv = parsed?.tv;
+  if (!tv) {
     return { channels: [], programmes: [] };
   }
+  return {
+    channels: normalizeXmlList(tv.channel),
+    programmes: normalizeXmlList(tv.programme),
+  };
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -238,16 +213,22 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
           }
         }
         const currentChannel = chList[0];
-        const currentChannelName = (currentChannel['display-name'] as string)?.trim().toLowerCase();
+        const currentChannelName = readXmlText(currentChannel?.['display-name']).toLowerCase();
         const json: EpgChannelJson = {
           channel: currentChannelName,
-          epg_data: progList.map((prog) => ({
-            start: formatTime(
-              utcDate((prog['@_start'] as { '#text'?: string })['#text'] as string)
-            ),
-            end: formatTime(utcDate((prog['@_stop'] as { '#text'?: string })['#text'] as string)),
-            title: prog.title as string,
-          })),
+          epg_data: progList
+            .map((prog) => {
+              const start = readXmlAttr(prog, 'start');
+              const stop = readXmlAttr(prog, 'stop');
+              if (!start || !stop) return null;
+
+              return {
+                start: formatTime(utcDate(start)),
+                end: formatTime(utcDate(stop)),
+                title: readXmlText(prog.title),
+              };
+            })
+            .filter((item): item is EpgChannelJson['epg_data'][number] => item !== null),
         };
         const savePath = await mkdir(path.join(basePath, currentChannelName), { recursive: true });
         await writeFile(
@@ -270,7 +251,7 @@ export async function buildEpgPwXml(batchSize = 10, delayMs = 300): Promise<stri
     `[EPG.PW] Done — ${seenChannelIds.size} channels, ${programmeNodes.length} programmes`
   );
 
-  const tvBody = epgPwBuilder.build({
+  const tvBody = buildXmlDocument({
     tv: {
       channel: channelNodes,
       programme: programmeNodes,

--- a/src/epgs/parser.ts
+++ b/src/epgs/parser.ts
@@ -5,10 +5,12 @@
 
 import {
   normalizeXmlList,
-  parseXmlDocument,
   readXmlAttr,
-  readXmlText,
-  type XmlNodeWithAttributes,
+  readXmltvChannelName,
+  readXmltvProgrammeTitle,
+  parseXmltvRoot,
+  type XmltvChannelNode,
+  type XmltvProgrammeNode,
 } from './xml';
 
 export interface EpgProgrammeItem {
@@ -38,35 +40,15 @@ function parseXmltvTime(
   return { date, start: startTime, end: endTime };
 }
 
-type XmlTextNode = string | XmlNodeWithAttributes | Array<string | XmlNodeWithAttributes>;
-
-function pickTitle(programme: ParsedProgramme): string {
-  return readXmlText(programme.title);
-}
-
 /** 将频道名转为安全文件名（去掉非法字符） */
 export function sanitizeChannelFileName(channel: string): string {
   return channel.replace(/[/\\:*?"<>|]/g, '_').trim() || 'channel';
 }
 
-type ParsedProgramme = XmlNodeWithAttributes & {
-  $?: {
-    start?: string;
-    stop?: string;
-    channel?: string;
-  };
-  title?: XmlTextNode;
-};
+type ParsedProgramme = XmltvProgrammeNode;
 type ChannelId = string;
 type ChannelName = string;
-type ChannelFromXml = XmlNodeWithAttributes & {
-  $?: {
-    id?: string;
-    name?: string;
-  };
-  name?: string;
-  'display-name'?: XmlTextNode;
-};
+type ChannelFromXml = XmltvChannelNode;
 type ParsedChannel = Record<ChannelId, ChannelName>;
 
 function toProgrammeList(programme: unknown): ParsedProgramme[] {
@@ -74,11 +56,7 @@ function toProgrammeList(programme: unknown): ParsedProgramme[] {
 }
 
 function pickChannelName(channel: ChannelFromXml): string {
-  const displayName = readXmlText(channel['display-name']);
-  if (displayName) return displayName;
-  const nameFromAttr = readXmlAttr(channel, 'name');
-  if (nameFromAttr) return nameFromAttr;
-  return channel.name?.trim() ?? '';
+  return readXmltvChannelName(channel);
 }
 
 function toChannelList(channel: unknown): ParsedChannel {
@@ -98,8 +76,7 @@ function toChannelList(channel: unknown): ParsedChannel {
 export function parseEpgXml(
   xml: string
 ): Array<{ date: string; channel: string; item: EpgProgrammeItem }> {
-  const parsed = parseXmlDocument<{ tv?: { programme?: unknown; channel?: unknown } }>(xml);
-  const tv = parsed?.tv;
+  const tv = parseXmltvRoot(xml);
   if (!tv) return [];
 
   if (!tv.channel) {
@@ -117,7 +94,7 @@ export function parseEpgXml(
     const startAttr = readXmlAttr(p, 'start');
     const stopAttr = readXmlAttr(p, 'stop');
     const time = parseXmltvTime(startAttr, stopAttr);
-    const title = pickTitle(p);
+    const title = readXmltvProgrammeTitle(p);
     if (!channelId || !time) {
       continue;
     }

--- a/src/epgs/parser.ts
+++ b/src/epgs/parser.ts
@@ -12,6 +12,7 @@ import {
   type XmltvChannelNode,
   type XmltvProgrammeNode,
 } from './xml';
+import { parseXmltvTimeRange } from './time';
 
 export interface EpgProgrammeItem {
   start: string; // "HH:mm"
@@ -22,22 +23,6 @@ export interface EpgProgrammeItem {
 export interface EpgChannelJson {
   channel: string;
   epg_data: EpgProgrammeItem[];
-}
-
-/** XMLTV start/stop 格式: 20240314080000 +0800 → 提取 YYYYmmdd 与 HH:mm */
-function parseXmltvTime(
-  startStr: string,
-  stopStr: string
-): { date: string; start: string; end: string } | null {
-  const startMatch = startStr?.match(/^(\d{14})/);
-  const stopMatch = stopStr?.match(/^(\d{14})/);
-  if (!startMatch || !stopMatch) return null;
-  const start = startMatch[1];
-  const stop = stopMatch[1];
-  const date = `${start.slice(0, 4)}-${start.slice(4, 6)}-${start.slice(6, 8)}`;
-  const startTime = `${start.slice(8, 10)}:${start.slice(10, 12)}`;
-  const endTime = `${stop.slice(8, 10)}:${stop.slice(10, 12)}`;
-  return { date, start: startTime, end: endTime };
 }
 
 /** 将频道名转为安全文件名（去掉非法字符） */
@@ -93,7 +78,7 @@ export function parseEpgXml(
     const channelId = readXmlAttr(p, 'channel');
     const startAttr = readXmlAttr(p, 'start');
     const stopAttr = readXmlAttr(p, 'stop');
-    const time = parseXmltvTime(startAttr, stopAttr);
+    const time = parseXmltvTimeRange(startAttr, stopAttr);
     const title = readXmltvProgrammeTitle(p);
     if (!channelId || !time) {
       continue;

--- a/src/epgs/parser.ts
+++ b/src/epgs/parser.ts
@@ -1,9 +1,15 @@
 /**
  * 解析 XMLTV 格式 EPG XML，按日期、频道分组并转换为目标 JSON 结构
- * 使用 fast-xml-parser 解析
+ * 使用 xml2js 解析
  */
 
-import { XMLParser } from 'fast-xml-parser';
+import {
+  normalizeXmlList,
+  parseXmlDocument,
+  readXmlAttr,
+  readXmlText,
+  type XmlNodeWithAttributes,
+} from './xml';
 
 export interface EpgProgrammeItem {
   start: string; // "HH:mm"
@@ -32,18 +38,10 @@ function parseXmltvTime(
   return { date, start: startTime, end: endTime };
 }
 
-function pickTitle(programme: Record<string, unknown>): string {
-  const title = programme.title;
-  if (typeof title === 'string') return title.trim();
-  if (Array.isArray(title)) {
-    const first = title[0];
-    return typeof first === 'string'
-      ? first.trim()
-      : ((first as { '#text'?: string })?.['#text']?.trim() ?? '');
-  }
-  if (title && typeof title === 'object' && '#text' in title)
-    return String((title as { '#text': string })['#text']).trim();
-  return '';
+type XmlTextNode = string | XmlNodeWithAttributes | Array<string | XmlNodeWithAttributes>;
+
+function pickTitle(programme: ParsedProgramme): string {
+  return readXmlText(programme.title);
 }
 
 /** 将频道名转为安全文件名（去掉非法字符） */
@@ -51,54 +49,44 @@ export function sanitizeChannelFileName(channel: string): string {
   return channel.replace(/[/\\:*?"<>|]/g, '_').trim() || 'channel';
 }
 
-type ParsedProgramme = Record<string, unknown> & {
-  '@_start'?: string;
-  '@_stop'?: string;
-  '@_channel'?: string;
+type ParsedProgramme = XmlNodeWithAttributes & {
+  $?: {
+    start?: string;
+    stop?: string;
+    channel?: string;
+  };
+  title?: XmlTextNode;
 };
 type ChannelId = string;
 type ChannelName = string;
-type ChannelDisplayName =
-  | string
-  | { '#text'?: string }
-  | Array<string | { '#text'?: string }>;
-type ChannelFromXml = {
-  '@_id'?: string;
+type ChannelFromXml = XmlNodeWithAttributes & {
+  $?: {
+    id?: string;
+    name?: string;
+  };
   name?: string;
-  'display-name'?: ChannelDisplayName;
+  'display-name'?: XmlTextNode;
 };
 type ParsedChannel = Record<ChannelId, ChannelName>;
 
 function toProgrammeList(programme: unknown): ParsedProgramme[] {
-  if (!programme) return [];
-  if (Array.isArray(programme)) return programme as ParsedProgramme[];
-  return [programme as ParsedProgramme];
+  return normalizeXmlList(programme as ParsedProgramme | ParsedProgramme[] | undefined);
 }
 
 function pickChannelName(channel: ChannelFromXml): string {
-  const displayName = channel['display-name'];
-  if (typeof displayName === 'string') return displayName.trim();
-  if (Array.isArray(displayName)) {
-    const first = displayName[0];
-    if (typeof first === 'string') return first.trim();
-    return first?.['#text']?.trim() ?? '';
-  }
-  if (displayName && typeof displayName === 'object') {
-    return displayName['#text']?.trim() ?? '';
-  }
+  const displayName = readXmlText(channel['display-name']);
+  if (displayName) return displayName;
+  const nameFromAttr = readXmlAttr(channel, 'name');
+  if (nameFromAttr) return nameFromAttr;
   return channel.name?.trim() ?? '';
 }
 
 function toChannelList(channel: unknown): ParsedChannel {
   const parsedChannels: ParsedChannel = {};
-  if (!channel) return parsedChannels;
-  let channels: ChannelFromXml[] = channel as ChannelFromXml[];
-  if (!Array.isArray(channel)) {
-    channels = [channel as ChannelFromXml];
-  }
+  const channels = normalizeXmlList(channel as ChannelFromXml | ChannelFromXml[] | undefined);
 
   for (const c of channels) {
-    const id = c['@_id'] ?? '';
+    const id = readXmlAttr(c, 'id');
     parsedChannels[id] = pickChannelName(c);
   }
   return parsedChannels;
@@ -110,11 +98,7 @@ function toChannelList(channel: unknown): ParsedChannel {
 export function parseEpgXml(
   xml: string
 ): Array<{ date: string; channel: string; item: EpgProgrammeItem }> {
-  const parser = new XMLParser({
-    ignoreAttributes: false,
-    attributeNamePrefix: '@_',
-  });
-  const parsed = parser.parse(xml) as { tv?: { programme?: unknown; channel?: unknown } };
+  const parsed = parseXmlDocument<{ tv?: { programme?: unknown; channel?: unknown } }>(xml);
   const tv = parsed?.tv;
   if (!tv) return [];
 
@@ -129,9 +113,9 @@ export function parseEpgXml(
   const out: Array<{ date: string; channel: string; item: EpgProgrammeItem }> = [];
 
   for (const p of programmes) {
-    const channelId = (p['@_channel'] ?? '').trim();
-    const startAttr = (p['@_start'] ?? '').trim();
-    const stopAttr = (p['@_stop'] ?? '').trim();
+    const channelId = readXmlAttr(p, 'channel');
+    const startAttr = readXmlAttr(p, 'start');
+    const stopAttr = readXmlAttr(p, 'stop');
     const time = parseXmltvTime(startAttr, stopAttr);
     const title = pickTitle(p);
     if (!channelId || !time) {

--- a/src/epgs/time.ts
+++ b/src/epgs/time.ts
@@ -1,0 +1,46 @@
+export interface XmltvTimeRange {
+  date: string;
+  start: string;
+  end: string;
+}
+
+/** XMLTV start/stop 格式: 20240314080000 +0800 → 提取 YYYY-mm-dd 与 HH:mm */
+export function parseXmltvTimeRange(startStr: string, stopStr: string): XmltvTimeRange | null {
+  const startMatch = startStr?.match(/^(\d{14})/);
+  const stopMatch = stopStr?.match(/^(\d{14})/);
+  if (!startMatch || !stopMatch) return null;
+
+  const start = startMatch[1];
+  const stop = stopMatch[1];
+
+  return {
+    date: `${start.slice(0, 4)}-${start.slice(4, 6)}-${start.slice(6, 8)}`,
+    start: `${start.slice(8, 10)}:${start.slice(10, 12)}`,
+    end: `${stop.slice(8, 10)}:${stop.slice(10, 12)}`,
+  };
+}
+
+/**
+ * 将 XMLTV 时间戳（YYYYmmddHHMMSS +ZZZZ）按其前 14 位解析为 UTC 时间。
+ * epg.pw 返回的时间以 UTC 为准，时区偏移可忽略。
+ */
+export function parseXmltvUtcTimestamp(timeStr: string): Date | null {
+  const match = timeStr?.match(/^(\d{14})/);
+  if (!match) return null;
+
+  const compact = match[1];
+  const year = Number(compact.slice(0, 4));
+  const month = Number(compact.slice(4, 6)) - 1;
+  const day = Number(compact.slice(6, 8));
+  const hour = Number(compact.slice(8, 10));
+  const minute = Number(compact.slice(10, 12));
+  const second = Number(compact.slice(12, 14));
+
+  return new Date(Date.UTC(year, month, day, hour, minute, second));
+}
+
+export function formatHourMinute(date: Date): string {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+}

--- a/src/epgs/xml.ts
+++ b/src/epgs/xml.ts
@@ -6,6 +6,34 @@ export interface XmlNodeWithAttributes {
   [key: string]: unknown;
 }
 
+export type XmlTextNode = string | XmlNodeWithAttributes | Array<string | XmlNodeWithAttributes>;
+
+export interface XmltvProgrammeNode extends XmlNodeWithAttributes {
+  $?: {
+    start?: string;
+    stop?: string;
+    channel?: string;
+    [key: string]: string | undefined;
+  };
+  title?: XmlTextNode;
+  desc?: XmlTextNode;
+}
+
+export interface XmltvChannelNode extends XmlNodeWithAttributes {
+  $?: {
+    id?: string;
+    name?: string;
+    [key: string]: string | undefined;
+  };
+  name?: string;
+  'display-name'?: XmlTextNode;
+}
+
+export interface XmltvNode {
+  channel?: XmltvChannelNode | XmltvChannelNode[];
+  programme?: XmltvProgrammeNode | XmltvProgrammeNode[];
+}
+
 const XML_PARSE_OPTIONS: ParserOptions = {
   async: false,
   attrkey: '$',
@@ -73,4 +101,23 @@ export function readXmlText(node: unknown): string {
 export function readXmlAttr(node: XmlNodeWithAttributes | null | undefined, name: string): string {
   const value = node?.$?.[name];
   return typeof value === 'string' ? value.trim() : '';
+}
+
+export function readXmltvChannelName(node: XmltvChannelNode | null | undefined): string {
+  const displayName = readXmlText(node?.['display-name']);
+  if (displayName) return displayName;
+
+  const nameFromAttr = readXmlAttr(node, 'name');
+  if (nameFromAttr) return nameFromAttr;
+
+  return node?.name?.trim() ?? '';
+}
+
+export function readXmltvProgrammeTitle(node: XmltvProgrammeNode | null | undefined): string {
+  return readXmlText(node?.title);
+}
+
+export function parseXmltvRoot(xml: string): XmltvNode | null {
+  const parsed = parseXmlDocument<{ tv?: XmltvNode }>(xml);
+  return parsed?.tv ?? null;
 }

--- a/src/epgs/xml.ts
+++ b/src/epgs/xml.ts
@@ -1,0 +1,76 @@
+import { Builder, parseString, type BuilderOptions, type ParserOptions } from 'xml2js';
+
+export interface XmlNodeWithAttributes {
+  $?: Record<string, string | undefined>;
+  _?: string;
+  [key: string]: unknown;
+}
+
+const XML_PARSE_OPTIONS: ParserOptions = {
+  async: false,
+  attrkey: '$',
+  charkey: '_',
+  explicitArray: false,
+  explicitRoot: true,
+  trim: true,
+  mergeAttrs: false,
+};
+
+const XML_BUILD_OPTIONS: BuilderOptions = {
+  attrkey: '$',
+  charkey: '_',
+  headless: true,
+  renderOpts: {
+    pretty: false,
+  },
+};
+
+export function parseXmlDocument<T>(xml: string): T | null {
+  let parsed: T | null = null;
+  let parseError: Error | null = null;
+
+  parseString(xml, XML_PARSE_OPTIONS, (error, result) => {
+    if (error) {
+      parseError = error;
+      return;
+    }
+    parsed = result as T;
+  });
+
+  if (parseError) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function buildXmlDocument(document: object): string {
+  return new Builder(XML_BUILD_OPTIONS).buildObject(document);
+}
+
+export function normalizeXmlList<T>(node: T | T[] | null | undefined): T[] {
+  if (node === undefined || node === null) return [];
+  return Array.isArray(node) ? node : [node];
+}
+
+export function readXmlText(node: unknown): string {
+  if (typeof node === 'string') {
+    return node.trim();
+  }
+
+  if (Array.isArray(node)) {
+    return readXmlText(node[0]);
+  }
+
+  if (node && typeof node === 'object') {
+    const text = (node as XmlNodeWithAttributes)._;
+    return typeof text === 'string' ? text.trim() : '';
+  }
+
+  return '';
+}
+
+export function readXmlAttr(node: XmlNodeWithAttributes | null | undefined, name: string): string {
+  const value = node?.$?.[name];
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/test/epgs/epg_pw.test.ts
+++ b/test/epgs/epg_pw.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { buildPwChannelJson, parseChannelListFromHtml, parsePwEpgXml } from '../../src/epgs/epg_pw';
+
+describe('parseChannelListFromHtml', () => {
+  it('should extract unique channel ids and trim names', () => {
+    const html = `
+      <a href="/last/100.html?lang=zh-hans"> CCTV-1 综合 </a>
+      <a href="/last/100.html?lang=zh-hans">CCTV-1 综合</a>
+      <a href="/last/200.html?lang=zh-hans">北京卫视</a>
+    `;
+
+    expect(parseChannelListFromHtml(html)).toEqual([
+      { id: '100', name: 'CCTV-1 综合' },
+      { id: '200', name: '北京卫视' },
+    ]);
+  });
+});
+
+describe('parsePwEpgXml', () => {
+  it('should parse channel and programme nodes from XMLTV fragment', () => {
+    const xml = `<?xml version="1.0"?>
+<tv>
+  <channel id="100">
+    <display-name lang="zh">CCTV-1 综合</display-name>
+  </channel>
+  <programme start="20240314000000 +0000" stop="20240314010000 +0000" channel="100">
+    <title lang="zh">午夜新闻</title>
+  </programme>
+</tv>`;
+
+    const parsed = parsePwEpgXml(xml);
+
+    expect(parsed.channels).toHaveLength(1);
+    expect(parsed.programmes).toHaveLength(1);
+    expect(parsed.channels[0].$?.id).toBe('100');
+    expect(parsed.programmes[0].$?.channel).toBe('100');
+  });
+
+  it('should return empty arrays for malformed xml', () => {
+    expect(parsePwEpgXml('<tv><channel id="1"></tv>')).toEqual({
+      channels: [],
+      programmes: [],
+    });
+  });
+});
+
+describe('buildPwChannelJson', () => {
+  it('should convert UTC XMLTV programmes into TVBox json items', () => {
+    const xml = `<?xml version="1.0"?>
+<tv>
+  <channel id="100">
+    <display-name lang="zh">CCTV-1 综合</display-name>
+  </channel>
+  <programme start="20240314003000 +0000" stop="20240314010000 +0000" channel="100">
+    <title lang="zh">午夜新闻</title>
+  </programme>
+  <programme start="invalid" stop="20240314020000 +0000" channel="100">
+    <title>Should Skip</title>
+  </programme>
+</tv>`;
+
+    const parsed = parsePwEpgXml(xml);
+    const json = buildPwChannelJson(parsed.channels[0], parsed.programmes);
+
+    expect(json).toEqual({
+      channel: 'cctv-1 综合',
+      epg_data: [
+        {
+          start: '00:30',
+          end: '01:00',
+          title: '午夜新闻',
+        },
+      ],
+    });
+  });
+});

--- a/test/epgs/epg_pw.test.ts
+++ b/test/epgs/epg_pw.test.ts
@@ -17,7 +17,7 @@ describe('parseChannelListFromHtml', () => {
 });
 
 describe('parsePwEpgXml', () => {
-  it('should parse channel and programme nodes from XMLTV fragment', () => {
+  it('should parse a single channel and its programme nodes from XMLTV fragment', () => {
     const xml = `<?xml version="1.0"?>
 <tv>
   <channel id="100">
@@ -30,15 +30,14 @@ describe('parsePwEpgXml', () => {
 
     const parsed = parsePwEpgXml(xml);
 
-    expect(parsed.channels).toHaveLength(1);
+    expect(parsed.channel?.$?.id).toBe('100');
     expect(parsed.programmes).toHaveLength(1);
-    expect(parsed.channels[0].$?.id).toBe('100');
     expect(parsed.programmes[0].$?.channel).toBe('100');
   });
 
   it('should return empty arrays for malformed xml', () => {
     expect(parsePwEpgXml('<tv><channel id="1"></tv>')).toEqual({
-      channels: [],
+      channel: null,
       programmes: [],
     });
   });
@@ -60,7 +59,7 @@ describe('buildPwChannelJson', () => {
 </tv>`;
 
     const parsed = parsePwEpgXml(xml);
-    const json = buildPwChannelJson(parsed.channels[0], parsed.programmes);
+    const json = buildPwChannelJson(parsed.channel ?? undefined, parsed.programmes);
 
     expect(json).toEqual({
       channel: 'cctv-1 综合',

--- a/test/epgs/parser.test.ts
+++ b/test/epgs/parser.test.ts
@@ -45,6 +45,7 @@ describe('parseEpgXml', () => {
   it('should return empty array when empty or no tv', () => {
     expect(parseEpgXml('')).toEqual([]);
     expect(parseEpgXml('<root></root>')).toEqual([]);
+    expect(parseEpgXml('<tv><channel id="1"></tv>')).toEqual([]);
   });
 
   it('should parse XMLTV format and return date, channel, item', () => {
@@ -76,5 +77,46 @@ describe('parseEpgXml', () => {
     const xml = fs.readFileSync(path.join(__dirname, 'e.xml'), 'utf-8');
     const out = parseEpgXml(xml);
     expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('should parse text nodes with attributes via xml2js output shape', () => {
+    const xml = `<?xml version="1.0"?>
+<tv>
+  <channel id="1" name="Fallback Name">
+    <display-name lang="zh">CCTV-1 综合</display-name>
+  </channel>
+  <programme start="20240314080000 +0800" stop="20240314090000 +0800" channel="1">
+    <title lang="zh">朝闻天下</title>
+  </programme>
+</tv>`;
+
+    const out = parseEpgXml(xml);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      date: '2024-03-14',
+      channel: 'CCTV-1 综合',
+      item: {
+        start: '08:00',
+        end: '09:00',
+        title: '朝闻天下',
+      },
+    });
+  });
+
+  it('should fall back to channel name attribute when display-name is missing', () => {
+    const xml = `<?xml version="1.0"?>
+<tv>
+  <channel id="1" name="CCTV-2 财经" />
+  <programme start="20240314090000 +0800" stop="20240314100000 +0800" channel="1">
+    <title>第一时间</title>
+  </programme>
+</tv>`;
+
+    const out = parseEpgXml(xml);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].channel).toBe('CCTV-2 财经');
+    expect(out[0].item.title).toBe('第一时间');
   });
 });

--- a/test/epgs/time.test.ts
+++ b/test/epgs/time.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { formatHourMinute, parseXmltvTimeRange, parseXmltvUtcTimestamp } from '../../src/epgs/time';
+
+describe('parseXmltvTimeRange', () => {
+  it('should extract date and hh:mm from XMLTV timestamps', () => {
+    expect(parseXmltvTimeRange('20240314080000 +0800', '20240314093000 +0800')).toEqual({
+      date: '2024-03-14',
+      start: '08:00',
+      end: '09:30',
+    });
+  });
+
+  it('should return null when timestamps are invalid', () => {
+    expect(parseXmltvTimeRange('invalid', '20240314093000 +0800')).toBeNull();
+  });
+});
+
+describe('parseXmltvUtcTimestamp', () => {
+  it('should parse compact XMLTV timestamp as UTC date', () => {
+    const date = parseXmltvUtcTimestamp('20240314093000 +0000');
+
+    expect(date?.toISOString()).toBe('2024-03-14T09:30:00.000Z');
+  });
+
+  it('should return null for invalid timestamp', () => {
+    expect(parseXmltvUtcTimestamp('bad')).toBeNull();
+  });
+});
+
+describe('formatHourMinute', () => {
+  it('should format time as HH:mm', () => {
+    const date = new Date(Date.UTC(2024, 2, 14, 9, 5, 0));
+
+    expect(formatHourMinute(date)).toBe('09:05');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace `fast-xml-parser` with `xml2js` for XMLTV parsing and XML building
- extract shared XML helpers for parsing, XMLTV node typing, channel/title reading, and list normalization
- add shared XMLTV time helpers plus reusable epg.pw pure functions for HTML/XML-to-JSON transformation
- simplify epg.pw response parsing by treating each `channel_id` request as a single-channel XML payload
- extend tests to cover malformed XML, text nodes with attributes, channel-name fallback, epg.pw parsing, and shared time parsing
- remove stale epg.pw-only type aliases that no longer participate in the shared XMLTV flow

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdadd0c4-2d93-4d4a-9b36-4f8322fa698c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdadd0c4-2d93-4d4a-9b36-4f8322fa698c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

